### PR TITLE
Unwrap uns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.h5ad
 *.rds
-/tmp
-/data
+**/tmp
+**/data
 .DS_Store

--- a/R/h5ad2rds.R
+++ b/R/h5ad2rds.R
@@ -1,14 +1,20 @@
-library(log4r)
+log_layout <- log4r::default_log_layout()
+log_console_appender <- log4r::console_appender(layout = log_layout)
 
-log_layout <- default_log_layout()
-log_console_appender <- console_appender(layout = log_layout)
-log_file_appender <- file_appender(log_file_name,
-  append = TRUE,
-  layout = log_layout
-)
+appenders <- list(log_console_appender)
+
+if (exists("log_file_name")) {
+  log_file_appender <- log4r::file_appender(
+    log_file_name,
+    append = TRUE,
+    layout = log_layout
+  )
+  appenders <- list(log_console_appender, log_file_appender)
+}
+
 log <- log4r::logger(
   threshold = "DEBUG",
-  appenders = list(log_console_appender, log_file_appender)
+  appenders = appenders
 )
 
 log_info <- function(msg) {

--- a/R/h5ad2rds.R
+++ b/R/h5ad2rds.R
@@ -87,7 +87,6 @@ h5ad_to_seurat <- function(h5ad_path) {
   seurat_obj <- SeuratObject::AddMetaData(seurat_obj, adata$obs)
   log_debug("Add uns records in seurat@misc")
   for (key in names(adata$uns)) {
-    log_error(paste0(key, ":", adata$uns$key))
     SeuratObject::Misc(seurat_obj, key) <- adata$uns[[key]]
   }
 

--- a/R/h5ad2rds.R
+++ b/R/h5ad2rds.R
@@ -40,8 +40,8 @@ log_warn <- function(msg) {
 #' @details This function reads the h5ad file using 'rhdf5' package
 #' and create named list with all fields existing in the file. After that,
 #' Seurat5 object is created from the list.
-#' The package was created for Cell Annotation Platform (CAP) project and expects that AnnData file was created with
-#' python AnnData package of version 0.8+
+#' The package was created for Cell Annotation Platform project and expects
+#' that AnnData file was created with python AnnData package of version 0.8+
 #'
 #' Resulting Seurat object will have the only assay named 'RNA'.
 #'

--- a/R/h5ad2rds.R
+++ b/R/h5ad2rds.R
@@ -79,7 +79,7 @@ h5ad_to_seurat <- function(h5ad_path) {
     main_assay <- SeuratObject::AddMetaData(
       main_assay,
       adata$var
-    ) # use raw as it is wider
+    )
   }
   log_debug("Create Seurat ojbect from Assay5")
   seurat_obj <- SeuratObject::CreateSeuratObject(main_assay)
@@ -504,13 +504,13 @@ read_h5ad <- function(path) {
   raw <- get_raw_X_var(f)
   if (!is.null(raw)) {
     log_debug("Update rownames and colnames for raw data")
-    rownames(raw$X) <- rownames(var)
+    rownames(raw$X) <- rownames(raw$var)
     colnames(raw$X) <- rownames(obs)
   }
   layers <- get_layers(f)
   uns <- get_uns(f)
 
-  anndata <- list(X = x, obs = obs, var = var, obsm = obsm, raw = raw, layers = layers, uns = uns)
+  anndata <- list(X=x, obs=obs, var=var, obsm=obsm, raw=raw, layers=layers, uns=uns)
   log_info("Finish read_h5ad!")
   return(anndata)
 }


### PR DESCRIPTION
PR consists of: 
- adds uns records directly to misc instead of misc@uns
- Fixes conversion for filtered datasets (when `X.shape` != `raw.X.shape`)
- Fix logger run, the script couldn't work in isolated mode because the log file name variable was missing